### PR TITLE
test: return proper exit code in case of script failure

### DIFF
--- a/tmt/tests/test.sh
+++ b/tmt/tests/test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -exuo pipefail
 
 cd ../../ || exit 1
 


### PR DESCRIPTION
We have seen failed tests results that are reported by tmt as passed.

This is likely being caused by `exit 0` command at the end of `tmt/tests/test.sh` script. Even though a test case fails the script will exit with code zero.

In order to circumvent this, testing-farm/tmt working group recommended to include command `set -exuo pipefail`