### PR TITLE
test: install openshift client

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -41,7 +41,7 @@ sudo dnf install -y glibc-langpack-en
 sudo localectl set-locale LANG=en_US.UTF-8
 
 # Install openshift client
-# curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | sudo tar -xz -C /usr/local/bin/
+curl https://mirror.openshift.com/pub/openshift-v4/clients/ocp/stable/openshift-client-linux.tar.gz | sudo tar -xz -C /usr/local/bin/
 
 # Install required packages
 greenprint "Install required packages"


### PR DESCRIPTION
We need to install Openshift Client to make edge-installer and iot-installer work.