### PR TITLE
test: include distro variable explicitly in Fedora-39

### DIFF
--- a/.github/workflows/fedora-39.yml
+++ b/.github/workflows/fedora-39.yml
@@ -59,6 +59,7 @@ jobs:
         with:
           compose: Fedora-39-Updated
           arch: x86_64
+          distro: fedora
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}
@@ -87,6 +88,7 @@ jobs:
         with:
           compose: Fedora-39-Updated
           arch: aarch64
+          distro: fedora
           api_key: ${{ secrets.TF_API_KEY }}
           git_url: ${{ needs.pr-info.outputs.repo_url }}
           git_ref: ${{ needs.pr-info.outputs.ref }}


### PR DESCRIPTION
I need to check why test plan is not paying attention to distribution. In order to do so, I defined explicitly distro variable as 'fedora' in the yaml file. 